### PR TITLE
Finalize THPTQG exam format migration

### DIFF
--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -63,6 +63,7 @@ from judge.views import (
     bookmark,
     widgets,
     internal,
+    exam,
 )
 from judge.views.problem_data import (
     ProblemDataView,
@@ -528,6 +529,7 @@ urlpatterns = [
                     name="contest_ranking_ajax",
                 ),
                 url(r"^/join$", contests.ContestJoin.as_view(), name="contest_join"),
+                url(r"^/exam/$", exam.ContestExamView.as_view(), name="contest_exam"),
                 url(r"^/leave$", contests.ContestLeave.as_view(), name="contest_leave"),
                 url(r"^/stats$", contests.ContestStats.as_view(), name="contest_stats"),
                 url(

--- a/judge/admin/__init__.py
+++ b/judge/admin/__init__.py
@@ -3,6 +3,7 @@ from django.contrib.admin.models import LogEntry
 
 from judge.admin.comments import CommentAdmin
 from judge.admin.contest import ContestAdmin, ContestParticipationAdmin, ContestTagAdmin
+from judge.admin.exam import ExamPaperAdmin
 from judge.admin.interface import (
     BlogPostAdmin,
     LicenseAdmin,

--- a/judge/admin/exam.py
+++ b/judge/admin/exam.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from django import forms
+from django.contrib import admin
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from judge.models import ExamPaper
+from judge.utils.exam_import import (
+    extract_answer_text,
+    parse_answer_document,
+    parse_part1_lines,
+    parse_part2_lines,
+    parse_part3_lines,
+)
+
+
+class ExamPaperAdminForm(forms.ModelForm):
+    manual_part1 = forms.CharField(
+        label=_("Manual part I answers"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 6}),
+        help_text=_("One question per line, e.g. \"1. A\"."),
+    )
+    manual_part2 = forms.CharField(
+        label=_("Manual part II answers"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 6}),
+        help_text=_("Use Đ for true and S for false, e.g. \"1. Đ S S Đ\"."),
+    )
+    manual_part3 = forms.CharField(
+        label=_("Manual part III answers"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 6}),
+        help_text=_("One short answer per line, e.g. \"1. 12345\"."),
+    )
+    answer_file = forms.FileField(
+        label=_("Upload answer file"),
+        required=False,
+        help_text=_(
+            "Accepted .docx or .pdf with sections [PART1], [PART2], [PART3]. "
+            "Example: [PART1]\\n1. A\\n…"
+        ),
+    )
+
+    class Meta:
+        model = ExamPaper
+        fields = (
+            "contest",
+            "subject",
+            "part1_questions",
+            "part2_questions",
+            "part3_questions",
+            "pdf",
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk and not self.is_bound:
+            answers = self.instance.export_answers()
+            if answers["part1"]:
+                self.fields["manual_part1"].initial = self._format_part1(answers["part1"])
+            if answers["part2"]:
+                self.fields["manual_part2"].initial = self._format_part2(answers["part2"])
+            if answers["part3"]:
+                self.fields["manual_part3"].initial = self._format_part3(answers["part3"])
+
+    @staticmethod
+    def _format_part1(answers):
+        return "\n".join(f"{index}. {value}" for index, value in enumerate(answers, start=1))
+
+    @staticmethod
+    def _format_part2(answers):
+        lines = []
+        for index, values in enumerate(answers, start=1):
+            tokens = ["Đ" if value else "S" for value in values]
+            lines.append(f"{index}. {' '.join(tokens)}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_part3(answers):
+        return "\n".join(f"{index}. {value}" for index, value in enumerate(answers, start=1))
+
+    def clean(self):
+        cleaned = super().clean()
+        answer_file = cleaned.get("answer_file")
+        manual_values = (
+            cleaned.get("manual_part1"),
+            cleaned.get("manual_part2"),
+            cleaned.get("manual_part3"),
+        )
+        has_manual = any(value for value in manual_values)
+
+        if answer_file and has_manual:
+            raise ValidationError(
+                _("Choose either manual answers or an uploaded file, not both."),
+            )
+
+        parsed_answers = {}
+
+        try:
+            if answer_file:
+                text = extract_answer_text(answer_file)
+                answer_file.seek(0)
+                parsed = parse_answer_document(text)
+                parsed_answers = {k: v for k, v in parsed.items() if v is not None}
+            elif has_manual:
+                if cleaned.get("manual_part1"):
+                    parsed_answers["part1"] = parse_part1_lines(
+                        cleaned["manual_part1"].splitlines()
+                    )
+                if cleaned.get("manual_part2"):
+                    parsed_answers["part2"] = parse_part2_lines(
+                        cleaned["manual_part2"].splitlines()
+                    )
+                if cleaned.get("manual_part3"):
+                    parsed_answers["part3"] = parse_part3_lines(
+                        cleaned["manual_part3"].splitlines()
+                    )
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+
+        cleaned["parsed_answers"] = parsed_answers or None
+        return cleaned
+
+
+@admin.register(ExamPaper)
+class ExamPaperAdmin(admin.ModelAdmin):
+    form = ExamPaperAdminForm
+    list_display = (
+        "contest",
+        "subject",
+        "part1_questions",
+        "part2_questions",
+        "part3_questions",
+    )
+    search_fields = ("contest__name", "contest__key")
+    list_select_related = ("contest",)
+    readonly_fields = ("created_at", "updated_at")
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "contest",
+                    "subject",
+                    "pdf",
+                    "part1_questions",
+                    "part2_questions",
+                    "part3_questions",
+                )
+            },
+        ),
+        (
+            _("Answer key"),
+            {
+                "fields": (
+                    "manual_part1",
+                    "manual_part2",
+                    "manual_part3",
+                    "answer_file",
+                )
+            },
+        ),
+        (
+            _("Timestamps"),
+            {"fields": ("created_at", "updated_at"), "classes": ("collapse",)},
+        ),
+    )
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        parsed = form.cleaned_data.get("parsed_answers")
+        if parsed:
+            current = obj.export_answers()
+            data = {
+                "part1": parsed.get("part1", current.get("part1", [])),
+                "part2": parsed.get("part2", current.get("part2", [])),
+                "part3": parsed.get("part3", current.get("part3", [])),
+            }
+            obj.sync_from_answer_data(data)

--- a/judge/contest_format/__init__.py
+++ b/judge/contest_format/__init__.py
@@ -4,4 +4,5 @@ from judge.contest_format.ecoo import ECOOContestFormat
 from judge.contest_format.icpc import ICPCContestFormat
 from judge.contest_format.ioi import IOIContestFormat
 from judge.contest_format.new_ioi import NewIOIContestFormat
+from judge.contest_format.thptqg import THPTQGContestFormat
 from judge.contest_format.registry import choices, formats

--- a/judge/contest_format/thptqg.py
+++ b/judge/contest_format/thptqg.py
@@ -1,0 +1,205 @@
+from types import SimpleNamespace
+
+from django.core.exceptions import ValidationError
+from django.template.defaultfilters import floatformat
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext, gettext_lazy
+
+from judge.contest_format.base import BaseContestFormat
+from judge.contest_format.registry import register_contest_format
+from judge.models.exam import ExamPaper, ExamQuestion, ExamResponse
+
+
+@register_contest_format("thptqg")
+class THPTQGContestFormat(BaseContestFormat):
+    name = gettext_lazy("THPTQG Exam")
+
+    @classmethod
+    def validate(cls, config):
+        if config is None:
+            return
+        if not isinstance(config, dict):
+            raise ValidationError("thptqg contest expects a configuration dict")
+        allowed_keys = {"subject"}
+        unknown = set(config) - allowed_keys
+        if unknown:
+            raise ValidationError(
+                "Invalid configuration keys for THPTQG contest: %s"
+                % ", ".join(sorted(unknown))
+            )
+        subject = config.get("subject")
+        if subject is not None and not isinstance(subject, str):
+            raise ValidationError("subject must be a string if provided")
+
+    def __init__(self, contest, config):
+        super(THPTQGContestFormat, self).__init__(contest, config or {})
+
+    def update_participation(self, participation):
+        try:
+            paper = self.contest.exam_paper
+        except ExamPaper.DoesNotExist:
+            participation.cumtime = 0
+            participation.tiebreaker = 0
+            participation.score = 0
+            participation.format_data = {"_aggregate": {"score": 0}}
+            participation.save()
+            return
+
+        questions = list(
+            paper.questions.select_related("paper").prefetch_related("choices")
+        )
+        responses = {
+            response.question_id: response
+            for response in ExamResponse.objects.filter(
+                participation=participation, question__paper=paper
+            )
+        }
+
+        format_data = {}
+        total_raw_points = 0.0
+        total_max_points = 0.0
+        total_correct_items = 0
+        total_items = 0
+
+        part_groups = {
+            "part1": [],
+            "part2": [],
+            "part3": [],
+        }
+        for question in questions:
+            if question.part == ExamQuestion.PART_MULTIPLE_CHOICE:
+                part_groups["part1"].append(question)
+            elif question.part == ExamQuestion.PART_TRUE_FALSE:
+                part_groups["part2"].append(question)
+            elif question.part == ExamQuestion.PART_SHORT_ANSWER:
+                part_groups["part3"].append(question)
+
+        for key, part_questions in part_groups.items():
+            if not part_questions:
+                continue
+            entry = {
+                "points": 0.0,
+                "max_points": 0.0,
+                "correct": 0,
+                "total": 0,
+                "questions": len(part_questions),
+            }
+
+            for question in part_questions:
+                entry["max_points"] += float(question.max_points or 0.0)
+                entry["total"] += question.total_items
+                total_max_points += float(question.max_points or 0.0)
+                total_items += question.total_items
+
+                response = responses.get(question.id)
+                if response:
+                    entry["points"] += float(response.points)
+                    entry["correct"] += response.correct_count
+                    total_raw_points += float(response.points)
+                    total_correct_items += response.correct_count
+                else:
+                    total_correct_items += 0
+
+            format_data[key] = entry
+
+        if total_max_points:
+            scaled_score = total_raw_points / total_max_points * 10
+        else:
+            scaled_score = 0.0
+
+        aggregate = {
+            "raw_points": round(total_raw_points, 3),
+            "max_points": round(total_max_points, 3),
+            "correct_items": total_correct_items,
+            "total_items": total_items,
+            "score": scaled_score,
+        }
+        format_data["_aggregate"] = aggregate
+
+        participation.cumtime = 0
+        participation.tiebreaker = 0
+        participation.score = round(scaled_score, self.contest.points_precision)
+        participation.format_data = format_data
+        participation.save()
+
+    def display_user_problem(self, participation, contest_problem):
+        key = getattr(contest_problem, "format_part_key", None)
+        if key is None:
+            return mark_safe('<td class="problem-score-col"></td>')
+
+        data = (participation.format_data or {}).get(key)
+        if not data:
+            return mark_safe('<td class="problem-score-col"></td>')
+
+        detail = format_html(
+            '<div class="exam-points">{points}</div>'
+            '<div class="exam-correct">{correct}/{total}</div>'
+            '<div class="exam-questions">{answered}</div>',
+            points=floatformat(data.get("points", 0), -self.contest.points_precision),
+            correct=data.get("correct", 0),
+            total=data.get("total", 0),
+            answered=gettext("%(count)s questions")
+            % {"count": data.get("questions", 0)},
+        )
+        return format_html(
+            '<td class="problem-score-col exam-part">{detail}</td>',
+            detail=detail,
+        )
+
+    def display_participation_result(self, participation):
+        aggregate = (participation.format_data or {}).get("_aggregate", {})
+        score = aggregate.get("score", participation.score)
+        return format_html(
+            '<td class="user-points exam-summary">'
+            "<div class=\"exam-score\">{score}/10</div>"
+            "<div class=\"exam-raw\">{raw}/{max_points}</div>"
+            "<div class=\"exam-correct\">{correct}/{total}</div>"
+            "</td>",
+            score=floatformat(score, -self.contest.points_precision),
+            raw=floatformat(aggregate.get("raw_points", 0), 2),
+            max_points=floatformat(aggregate.get("max_points", 0), 2),
+            correct=aggregate.get("correct_items", 0),
+            total=aggregate.get("total_items", 0),
+        )
+
+    def get_problem_breakdown(self, participation, contest_problems):
+        format_data = participation.format_data or {}
+        return [
+            format_data.get(getattr(contest_problem, "format_part_key", ""), {})
+            for contest_problem in contest_problems
+        ]
+
+    def get_contest_problem_label_script(self):
+        return """
+            function(n)
+                return tostring(math.floor(n + 1))
+            end
+        """
+
+    def get_virtual_parts(self):
+        try:
+            paper = self.contest.exam_paper
+        except ExamPaper.DoesNotExist:
+            return []
+
+        parts = []
+        labels = {
+            "part1": gettext("Part I"),
+            "part2": gettext("Part II"),
+            "part3": gettext("Part III"),
+        }
+        max_points = paper.max_points_by_part()
+        for key in ("part1", "part2", "part3"):
+            if key == "part3" and not paper.part3_questions:
+                continue
+            points = max_points.get(key, 0.0)
+            label = labels.get(key, key.title())
+            part = SimpleNamespace(
+                format_part_key=key,
+                label=label,
+                points=points,
+                problem=SimpleNamespace(name=label, code=key.upper()),
+            )
+            parts.append(part)
+        return parts

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -33,6 +33,7 @@ from judge.models import (
     Submission,
     BlogPost,
     ContestProblem,
+    ExamQuestion,
 )
 from judge.utils.subscription import newsletter_id
 from judge.widgets import (
@@ -492,3 +493,116 @@ class ContestProblemFormSet(
     )
 ):
     model = ContestProblem
+
+
+class ExamSheetForm(Form):
+    def __init__(
+        self,
+        *args,
+        paper,
+        questions,
+        responses,
+        **kwargs,
+    ):
+        self.paper = paper
+        self.questions = questions
+        self.responses = responses or {}
+        self.choice_lookup = {}
+        self.part1_questions = []
+        self.part2_questions = []
+        self.part3_questions = []
+        self.multiple_choice_field_map = []
+        self.true_false_field_map = {}
+        self.short_answer_field_map = []
+        super().__init__(*args, **kwargs)
+        self._build_fields()
+
+    def _build_fields(self):
+        part1 = [
+            q
+            for q in self.questions
+            if q.part == ExamQuestion.PART_MULTIPLE_CHOICE
+        ]
+        part2 = [
+            q for q in self.questions if q.part == ExamQuestion.PART_TRUE_FALSE
+        ]
+        part3 = [
+            q for q in self.questions if q.part == ExamQuestion.PART_SHORT_ANSWER
+        ]
+
+        for question in part1:
+            field_name = f"p1_q{question.number}"
+            ordered_choices = list(question.choices.order_by("key"))
+            choices = [
+                (option.key.upper(), option.key.upper()) for option in ordered_choices
+            ]
+            self.fields[field_name] = ChoiceField(
+                label="",
+                choices=choices,
+                widget=forms.RadioSelect,
+                required=False,
+            )
+            choice_map = {option.key.upper(): option for option in ordered_choices}
+            self.choice_lookup[question.id] = choice_map
+            response = self.responses.get(question.id)
+            if response and response.selected_choice:
+                self.initial[field_name] = response.selected_choice.key.upper()
+            self.multiple_choice_field_map.append((question, field_name))
+            self.part1_questions.append((question, self[field_name]))
+
+        for question in part2:
+            statement_fields = []
+            response = self.responses.get(question.id)
+            answers = {}
+            if response and response.true_false_answers:
+                answers = {
+                    str(k): bool(v)
+                    for k, v in response.true_false_answers.items()
+                }
+            ordered_choices = list(question.choices.order_by("key"))
+            self.true_false_field_map[question] = []
+            for choice in ordered_choices:
+                field_name = f"p2_q{question.number}_{choice.key}"
+                self.fields[field_name] = ChoiceField(
+                    label="",
+                    choices=[("true", _("True")), ("false", _("False"))],
+                    widget=forms.RadioSelect,
+                    required=False,
+                )
+                if str(choice.id) in answers:
+                    self.initial[field_name] = "true" if answers[str(choice.id)] else "false"
+                self.true_false_field_map[question].append((choice, field_name))
+                statement_fields.append((choice, self[field_name]))
+            self.part2_questions.append((question, statement_fields))
+
+        for question in part3:
+            field_name = f"p3_q{question.number}"
+            self.fields[field_name] = CharField(
+                label="",
+                max_length=64,
+                required=False,
+                widget=forms.TextInput(
+                    attrs={
+                        "class": "short-answer-field",
+                        "autocomplete": "off",
+                        "spellcheck": "false",
+                    }
+                ),
+            )
+            response = self.responses.get(question.id)
+            if response:
+                self.initial[field_name] = response.short_answer_text
+            self.short_answer_field_map.append((question, field_name))
+            self.part3_questions.append((question, self[field_name]))
+
+    def iter_part1(self):
+        for question, bound_field in self.part1_questions:
+            yield question, bound_field
+
+    def iter_part2(self):
+        for question, fields in self.part2_questions:
+            yield question, fields
+
+    def iter_part3(self):
+        for question, bound_field in self.part3_questions:
+            yield question, bound_field

--- a/judge/jinja2/markdown/__init__.py
+++ b/judge/jinja2/markdown/__init__.py
@@ -36,7 +36,7 @@ EXTENSION_CONFIGS = {
     },
 }
 
-ALLOWED_TAGS = bleach.sanitizer.ALLOWED_TAGS + [
+ALLOWED_TAGS = list(bleach.sanitizer.ALLOWED_TAGS) + [
     "img",
     "center",
     "iframe",

--- a/judge/migrations/0141_exam_models.py
+++ b/judge/migrations/0141_exam_models.py
@@ -1,0 +1,122 @@
+# Generated manually for exam models
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("judge", "0140_alter_contest_format_name"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ExamQuestion",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("part", models.CharField(choices=[
+                    ("multiple_choice", "Multiple choice"),
+                    ("true_false", "True/False"),
+                    ("short_answer", "Short answer"),
+                ], max_length=32)),
+                ("prompt", models.TextField(verbose_name="question prompt")),
+                ("max_points", models.FloatField(default=0.25)),
+                (
+                    "short_answer",
+                    models.CharField(
+                        blank=True,
+                        help_text="Expected answer for short-answer questions.",
+                        max_length=64,
+                        verbose_name="short answer",
+                    ),
+                ),
+                (
+                    "contest_problem",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="exam_question",
+                        to="judge.contestproblem",
+                        verbose_name="contest problem",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "exam question",
+                "verbose_name_plural": "exam questions",
+            },
+        ),
+        migrations.CreateModel(
+            name="ExamChoice",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("key", models.CharField(max_length=16, verbose_name="label")),
+                ("text", models.TextField(blank=True, verbose_name="text")),
+                ("is_correct", models.BooleanField(default=False, verbose_name="is correct")),
+                (
+                    "question",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="choices",
+                        to="judge.examquestion",
+                        verbose_name="question",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["key"],
+                "verbose_name": "exam choice",
+                "verbose_name_plural": "exam choices",
+            },
+        ),
+        migrations.CreateModel(
+            name="ExamResponse",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("true_false_answers", jsonfield.fields.JSONField(blank=True, null=True)),
+                ("short_answer_text", models.CharField(blank=True, max_length=64)),
+                ("submitted_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("points", models.FloatField(default=0)),
+                ("correct_count", models.PositiveIntegerField(default=0)),
+                ("total_count", models.PositiveIntegerField(default=0)),
+                (
+                    "participation",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="exam_responses",
+                        to="judge.contestparticipation",
+                        verbose_name="participation",
+                    ),
+                ),
+                (
+                    "question",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="responses",
+                        to="judge.examquestion",
+                        verbose_name="question",
+                    ),
+                ),
+                (
+                    "selected_choice",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="responses",
+                        to="judge.examchoice",
+                        verbose_name="selected choice",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "exam response",
+                "verbose_name_plural": "exam responses",
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name="examresponse",
+            unique_together={("question", "participation")},
+        ),
+    ]

--- a/judge/migrations/0142_auto_20250922_2357.py
+++ b/judge/migrations/0142_auto_20250922_2357.py
@@ -1,0 +1,163 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import judge.models.choices
+import judge.models.exam
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("judge", "0141_exam_models"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="examquestion",
+            options={
+                "ordering": ["paper_id", "part", "number"],
+                "verbose_name": "exam question",
+                "verbose_name_plural": "exam questions",
+            },
+        ),
+        migrations.AddField(
+            model_name="examquestion",
+            name="number",
+            field=models.PositiveIntegerField(default=1),
+        ),
+        migrations.AlterField(
+            model_name="contest",
+            name="format_name",
+            field=models.CharField(
+                choices=[
+                    ("atcoder", "AtCoder"),
+                    ("default", "Default"),
+                    ("ecoo", "ECOO"),
+                    ("icpc", "ICPC"),
+                    ("ioi", "IOI"),
+                    ("ioi16", "New IOI"),
+                    ("thptqg", "THPTQG Exam"),
+                ],
+                default="default",
+                help_text="The contest format module to use.",
+                max_length=32,
+                verbose_name="contest format",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="examquestion",
+            name="contest_problem",
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="exam_question",
+                to="judge.contestproblem",
+                verbose_name="contest problem",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="examquestion",
+            name="prompt",
+            field=models.TextField(blank=True, verbose_name="question prompt"),
+        ),
+        migrations.AlterField(
+            model_name="profile",
+            name="timezone",
+            field=models.CharField(
+                choices=judge.models.choices.TIMEZONE,
+                default=settings.DEFAULT_USER_TIME_ZONE,
+                max_length=50,
+                verbose_name="location",
+            ),
+        ),
+        migrations.CreateModel(
+            name="ExamPaper",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "subject",
+                    models.CharField(
+                        choices=[
+                            ("math", "Mathematics"),
+                            ("physics", "Physics"),
+                            ("chemistry", "Chemistry"),
+                            ("biology", "Biology"),
+                            ("history", "History"),
+                            ("geography", "Geography"),
+                            ("civic_education", "Civic education"),
+                            ("english", "English"),
+                            ("foreign_language", "Other foreign language"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                (
+                    "part1_questions",
+                    models.PositiveIntegerField(
+                        default=40, verbose_name="part I questions"
+                    ),
+                ),
+                (
+                    "part2_questions",
+                    models.PositiveIntegerField(
+                        default=8, verbose_name="part II questions"
+                    ),
+                ),
+                (
+                    "part3_questions",
+                    models.PositiveIntegerField(
+                        default=6, verbose_name="part III questions"
+                    ),
+                ),
+                (
+                    "pdf",
+                    models.FileField(
+                        blank=True,
+                        null=True,
+                        upload_to=judge.models.exam.exam_pdf_upload_to,
+                        verbose_name="exam PDF",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "contest",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="exam_paper",
+                        to="judge.contest",
+                        verbose_name="contest",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "exam paper",
+                "verbose_name_plural": "exam papers",
+            },
+        ),
+        migrations.AddField(
+            model_name="examquestion",
+            name="paper",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="questions",
+                to="judge.exampaper",
+                verbose_name="exam paper",
+            ),
+        ),
+        migrations.AlterUniqueTogether(
+            name="examquestion",
+            unique_together={("paper", "part", "number")},
+        ),
+    ]

--- a/judge/models/__init__.py
+++ b/judge/models/__init__.py
@@ -17,6 +17,7 @@ from judge.models.contest import (
     Rating,
     ContestProblemClarification,
 )
+from judge.models.exam import ExamChoice, ExamPaper, ExamQuestion, ExamResponse
 from judge.models.interface import BlogPost, MiscConfig, NavigationBar, validate_regex
 from judge.models.message import PrivateMessage, PrivateMessageThread
 from judge.models.problem import (
@@ -63,6 +64,10 @@ revisions.register(LanguageLimit)
 revisions.register(LanguageTemplate)
 revisions.register(Contest, follow=["contest_problems"])
 revisions.register(ContestProblem)
+revisions.register(ExamPaper)
+revisions.register(ExamQuestion)
+revisions.register(ExamChoice)
+revisions.register(ExamResponse)
 revisions.register(Organization)
 revisions.register(BlogPost)
 revisions.register(Solution)

--- a/judge/models/exam.py
+++ b/judge/models/exam.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterable, List, Tuple
+
+from django.db import models, transaction
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from jsonfield import JSONField
+
+
+def exam_pdf_upload_to(instance: "ExamPaper", filename: str) -> str:
+    contest_key = instance.contest.key if instance.contest_id else "contest"
+    return os.path.join("exam_papers", contest_key, filename)
+
+
+class ExamPaper(models.Model):
+    SUBJECT_MATH = "math"
+    SUBJECT_PHYSICS = "physics"
+    SUBJECT_CHEMISTRY = "chemistry"
+    SUBJECT_BIOLOGY = "biology"
+    SUBJECT_HISTORY = "history"
+    SUBJECT_GEOGRAPHY = "geography"
+    SUBJECT_CIVIC = "civic_education"
+    SUBJECT_ENGLISH = "english"
+    SUBJECT_FOREIGN_LANGUAGE = "foreign_language"
+
+    SUBJECT_CHOICES = (
+        (SUBJECT_MATH, _("Mathematics")),
+        (SUBJECT_PHYSICS, _("Physics")),
+        (SUBJECT_CHEMISTRY, _("Chemistry")),
+        (SUBJECT_BIOLOGY, _("Biology")),
+        (SUBJECT_HISTORY, _("History")),
+        (SUBJECT_GEOGRAPHY, _("Geography")),
+        (SUBJECT_CIVIC, _("Civic education")),
+        (SUBJECT_ENGLISH, _("English")),
+        (SUBJECT_FOREIGN_LANGUAGE, _("Other foreign language")),
+    )
+
+    contest = models.OneToOneField(
+        "judge.Contest",
+        related_name="exam_paper",
+        on_delete=models.CASCADE,
+        verbose_name=_("contest"),
+    )
+    subject = models.CharField(max_length=32, choices=SUBJECT_CHOICES)
+    part1_questions = models.PositiveIntegerField(
+        default=40, verbose_name=_("part I questions")
+    )
+    part2_questions = models.PositiveIntegerField(
+        default=8, verbose_name=_("part II questions")
+    )
+    part3_questions = models.PositiveIntegerField(
+        default=6, verbose_name=_("part III questions")
+    )
+    pdf = models.FileField(
+        upload_to=exam_pdf_upload_to,
+        blank=True,
+        null=True,
+        verbose_name=_("exam PDF"),
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = _("exam paper")
+        verbose_name_plural = _("exam papers")
+
+    def __str__(self) -> str:
+        return f"{self.contest.name} – {self.get_subject_display()}"
+
+    @property
+    def part1_point_value(self) -> float:
+        return 0.25
+
+    @property
+    def part2_point_value(self) -> float:
+        return 1.0
+
+    @property
+    def part3_point_value(self) -> float:
+        return 0.5 if self.subject == self.SUBJECT_MATH else 0.25
+
+    @property
+    def true_false_items(self) -> int:
+        return 4
+
+    def questions_for_part(self, part: str) -> Iterable["ExamQuestion"]:
+        return self.questions.filter(part=part).order_by("number")
+
+    def max_points_by_part(self) -> Dict[str, float]:
+        return {
+            "part1": self.part1_questions * self.part1_point_value,
+            "part2": self.part2_questions * self.part2_point_value,
+            "part3": self.part3_questions * self.part3_point_value,
+        }
+
+    def total_max_points(self) -> float:
+        values = self.max_points_by_part()
+        return sum(values.values())
+
+    def export_answers(self) -> Dict[str, List[str]]:
+        data: Dict[str, List] = {"part1": [], "part2": [], "part3": []}
+        for question in self.questions.select_related(None).prefetch_related("choices").order_by(
+            "part", "number"
+        ):
+            if question.part == ExamQuestion.PART_MULTIPLE_CHOICE:
+                choice = question.choices.filter(is_correct=True).first()
+                data["part1"].append(choice.key.upper() if choice else "")
+            elif question.part == ExamQuestion.PART_TRUE_FALSE:
+                ordered_choices = list(question.choices.order_by("key"))
+                values = [bool(c.is_correct) for c in ordered_choices]
+                data["part2"].append(values)
+            elif question.part == ExamQuestion.PART_SHORT_ANSWER:
+                data["part3"].append(question.short_answer or "")
+        return data
+
+    def sync_from_answer_data(self, answers: Dict[str, List]) -> None:
+        part1 = answers.get("part1", [])
+        part2 = answers.get("part2", [])
+        part3 = answers.get("part3", [])
+
+        with transaction.atomic():
+            self.questions.all().delete()
+
+            self.part1_questions = len(part1)
+            self.part2_questions = len(part2)
+            self.part3_questions = len(part3)
+            self.save(
+                update_fields=[
+                    "part1_questions",
+                    "part2_questions",
+                    "part3_questions",
+                    "updated_at",
+                ]
+            )
+
+            for index, correct in enumerate(part1, start=1):
+                question = ExamQuestion.objects.create(
+                    paper=self,
+                    part=ExamQuestion.PART_MULTIPLE_CHOICE,
+                    number=index,
+                    prompt=f"Phần I – Câu {index}",
+                    max_points=self.part1_point_value,
+                )
+                for option in ("A", "B", "C", "D"):
+                    ExamChoice.objects.create(
+                        question=question,
+                        key=option,
+                        is_correct=option == correct,
+                    )
+
+            for index, statement_answers in enumerate(part2, start=1):
+                question = ExamQuestion.objects.create(
+                    paper=self,
+                    part=ExamQuestion.PART_TRUE_FALSE,
+                    number=index,
+                    prompt=f"Phần II – Câu {index}",
+                    max_points=self.part2_point_value,
+                )
+                for offset, value in enumerate(statement_answers):
+                    label = chr(ord("a") + offset)
+                    ExamChoice.objects.create(
+                        question=question,
+                        key=label,
+                        is_correct=bool(value),
+                    )
+
+            for index, answer in enumerate(part3, start=1):
+                ExamQuestion.objects.create(
+                    paper=self,
+                    part=ExamQuestion.PART_SHORT_ANSWER,
+                    number=index,
+                    prompt=f"Phần III – Câu {index}",
+                    max_points=self.part3_point_value,
+                    short_answer=str(answer or "").strip(),
+                )
+
+
+class ExamQuestion(models.Model):
+    PART_MULTIPLE_CHOICE = "multiple_choice"
+    PART_TRUE_FALSE = "true_false"
+    PART_SHORT_ANSWER = "short_answer"
+    PART_CHOICES = (
+        (PART_MULTIPLE_CHOICE, _("Multiple choice")),
+        (PART_TRUE_FALSE, _("True/False")),
+        (PART_SHORT_ANSWER, _("Short answer")),
+    )
+
+    contest_problem = models.OneToOneField(
+        "judge.ContestProblem",
+        on_delete=models.CASCADE,
+        related_name="exam_question",
+        verbose_name=_("contest problem"),
+        null=True,
+        blank=True,
+    )
+    paper = models.ForeignKey(
+        ExamPaper,
+        related_name="questions",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        verbose_name=_("exam paper"),
+    )
+    part = models.CharField(max_length=32, choices=PART_CHOICES)
+    number = models.PositiveIntegerField(default=1)
+    prompt = models.TextField(verbose_name=_("question prompt"), blank=True)
+    max_points = models.FloatField(default=0.25)
+    short_answer = models.CharField(
+        max_length=64,
+        blank=True,
+        verbose_name=_("short answer"),
+        help_text=_("Expected answer for short-answer questions."),
+    )
+
+    class Meta:
+        verbose_name = _("exam question")
+        verbose_name_plural = _("exam questions")
+        ordering = ["paper_id", "part", "number"]
+        unique_together = ("paper", "part", "number")
+
+    def __str__(self) -> str:
+        if self.paper:
+            return f"{self.paper} – {self.get_part_display()} #{self.number}"
+        if self.contest_problem:
+            return f"{self.contest_problem} ({self.get_part_display()})"
+        return f"{self.get_part_display()} #{self.pk}"
+
+    def save(self, *args, **kwargs):
+        if not self.max_points:
+            if self.part == self.PART_TRUE_FALSE:
+                self.max_points = 1.0
+            elif self.part == self.PART_SHORT_ANSWER:
+                if self.paper:
+                    self.max_points = self.paper.part3_point_value
+                else:
+                    self.max_points = 0.25
+            else:
+                self.max_points = 0.25
+        super().save(*args, **kwargs)
+
+    @property
+    def total_items(self) -> int:
+        if self.part == self.PART_TRUE_FALSE:
+            return self.choices.count()
+        return 1
+
+    def default_max_points(self) -> float:
+        if self.part == self.PART_TRUE_FALSE:
+            return 1.0
+        if self.part == self.PART_SHORT_ANSWER:
+            return self.max_points or 0.25
+        return 0.25
+
+    def get_true_false_points(self, correct: int) -> float:
+        """Return the awarded points for a True/False question."""
+        score_map = {1: 0.1, 2: 0.25, 3: 0.5, 4: 1.0}
+        base = score_map.get(correct, 0)
+        return round(base * (self.max_points or 1.0), 3)
+
+    @staticmethod
+    def normalize_short_answer(value: str) -> str:
+        return (value or "").strip().lower()
+
+
+class ExamChoice(models.Model):
+    question = models.ForeignKey(
+        ExamQuestion,
+        on_delete=models.CASCADE,
+        related_name="choices",
+        verbose_name=_("question"),
+    )
+    key = models.CharField(max_length=16, verbose_name=_("label"))
+    text = models.TextField(blank=True, verbose_name=_("text"))
+    is_correct = models.BooleanField(default=False, verbose_name=_("is correct"))
+
+    class Meta:
+        verbose_name = _("exam choice")
+        verbose_name_plural = _("exam choices")
+        ordering = ["key"]
+
+    def __str__(self) -> str:
+        return f"{self.key}: {self.text[:30]}"
+
+
+class ExamResponse(models.Model):
+    question = models.ForeignKey(
+        ExamQuestion,
+        on_delete=models.CASCADE,
+        related_name="responses",
+        verbose_name=_("question"),
+    )
+    participation = models.ForeignKey(
+        "judge.ContestParticipation",
+        on_delete=models.CASCADE,
+        related_name="exam_responses",
+        verbose_name=_("participation"),
+    )
+    selected_choice = models.ForeignKey(
+        ExamChoice,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="responses",
+        verbose_name=_("selected choice"),
+    )
+    true_false_answers = JSONField(blank=True, null=True)
+    short_answer_text = models.CharField(max_length=64, blank=True)
+    submitted_at = models.DateTimeField(default=timezone.now)
+    points = models.FloatField(default=0)
+    correct_count = models.PositiveIntegerField(default=0)
+    total_count = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        unique_together = ("question", "participation")
+        verbose_name = _("exam response")
+        verbose_name_plural = _("exam responses")
+
+    def __str__(self) -> str:
+        return f"Response of {self.participation} to {self.question}"
+
+    def _grade_multiple_choice(self) -> Tuple[int, int, float]:
+        total = 1
+        correct = 0
+        if self.selected_choice and self.selected_choice.is_correct:
+            correct = 1
+            return correct, total, self.question.max_points or 0.25
+        return correct, total, 0.0
+
+    def _grade_true_false(self) -> Tuple[int, int, float]:
+        answers: Dict[str, bool] = {}
+        if isinstance(self.true_false_answers, dict):
+            answers = {str(k): bool(v) for k, v in self.true_false_answers.items()}
+        total = self.question.total_items or 4
+        correct = 0
+        for choice in self.question.choices.all():
+            user_answer = answers.get(str(choice.id))
+            if user_answer is None:
+                continue
+            if bool(user_answer) == bool(choice.is_correct):
+                correct += 1
+        points = self.question.get_true_false_points(correct)
+        return correct, total, points
+
+    def _grade_short_answer(self) -> Tuple[int, int, float]:
+        total = 1
+        correct = 0
+        expected = ExamQuestion.normalize_short_answer(self.question.short_answer)
+        given = ExamQuestion.normalize_short_answer(self.short_answer_text)
+        if expected and given and expected == given:
+            correct = 1
+            return correct, total, self.question.max_points or 0.25
+        return correct, total, 0.0
+
+    def grade(self) -> Tuple[int, int, float]:
+        if self.question.part == ExamQuestion.PART_MULTIPLE_CHOICE:
+            return self._grade_multiple_choice()
+        if self.question.part == ExamQuestion.PART_TRUE_FALSE:
+            return self._grade_true_false()
+        if self.question.part == ExamQuestion.PART_SHORT_ANSWER:
+            return self._grade_short_answer()
+        return 0, 0, 0.0
+
+    def save(self, *args, **kwargs):
+        recompute = kwargs.pop("recompute", True)
+        self.submitted_at = timezone.now()
+        correct, total, points = self.grade()
+        self.correct_count = correct
+        self.total_count = total
+        self.points = round(points, 3)
+        super().save(*args, **kwargs)
+        if recompute:
+            self.participation.recompute_results()

--- a/judge/utils/exam_import.py
+++ b/judge/utils/exam_import.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import re
+from io import BytesIO
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+from docx import Document
+from pdfminer.high_level import extract_text
+
+SECTION_RE = re.compile(r"\[(?:PART|PHẦN)\s*(\d)\]", re.IGNORECASE)
+INDEX_RE = re.compile(r"^(?:câu|question)?\s*(\d+)(?:[\.\-:)]\s*)?(.*)$", re.IGNORECASE)
+
+TRUE_VALUES = {"d", "đ", "t", "true", "y", "yes", "đúng"}
+FALSE_VALUES = {"s", "f", "false", "n", "no", "sai"}
+
+
+def extract_answer_text(uploaded_file) -> str:
+    name = (getattr(uploaded_file, "name", "") or "").lower()
+    if name.endswith(".docx"):
+        document = Document(uploaded_file)
+        return "\n".join(paragraph.text for paragraph in document.paragraphs)
+    if name.endswith(".pdf"):
+        data = uploaded_file.read()
+        return extract_text(BytesIO(data))
+    data = uploaded_file.read()
+    for encoding in ("utf-8", "utf-8-sig", "utf-16", "latin-1"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="ignore")
+
+
+def _iter_indexed_lines(lines: Iterable[str]) -> List[Tuple[int | None, str]]:
+    entries: List[Tuple[int | None, str]] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        match = INDEX_RE.match(line)
+        if match:
+            index = int(match.group(1))
+            remainder = match.group(2).strip()
+            entries.append((index, remainder))
+        else:
+            entries.append((None, line))
+    return entries
+
+
+def _normalize_order(entries: List[Tuple[int | None, str]], expected_count: int | None = None) -> List[str]:
+    normalized: List[Tuple[int, str]] = []
+    next_index = 1
+    seen = set()
+    for index, value in entries:
+        if index is None:
+            index = next_index
+        if index < 1 or index in seen:
+            raise ValueError("Invalid or duplicated question number")
+        normalized.append((index, value))
+        seen.add(index)
+        next_index = index + 1
+
+    normalized.sort(key=lambda item: item[0])
+    for expected, (index, _) in enumerate(normalized, start=1):
+        if index != expected:
+            raise ValueError("Missing question number {}".format(expected))
+
+    values = [value for _, value in normalized]
+    if expected_count is not None and len(values) != expected_count:
+        raise ValueError("Expected %d answers" % expected_count)
+    return values
+
+
+def parse_part1_lines(lines: Iterable[str], expected_count: int | None = None) -> List[str]:
+    answers: List[str] = []
+    normalized = _normalize_order(_iter_indexed_lines(lines), expected_count)
+    for value in normalized:
+        token = value.split()
+        if not token:
+            raise ValueError("Missing choice for a multiple-choice question")
+        candidate = re.sub(r"[^a-dA-D]", "", token[0]).upper()
+        if candidate not in {"A", "B", "C", "D"}:
+            raise ValueError("Invalid choice %s" % token[0])
+        answers.append(candidate)
+    return answers
+
+
+def _parse_true_false_token(token: str) -> bool:
+    cleaned = token.strip().lower()
+    cleaned = cleaned.replace(".", "")
+    if cleaned in TRUE_VALUES:
+        return True
+    if cleaned in FALSE_VALUES:
+        return False
+    raise ValueError("Invalid true/false value: %s" % token)
+
+
+def parse_part2_lines(
+    lines: Iterable[str],
+    statements: int = 4,
+    expected_count: int | None = None,
+) -> List[List[bool]]:
+    answers: List[List[bool]] = []
+    normalized = _normalize_order(_iter_indexed_lines(lines), expected_count)
+    for value in normalized:
+        tokens = [token for token in re.split(r"[\s,;]+", value) if token]
+        if len(tokens) != statements:
+            raise ValueError("Each True/False question must have %d values" % statements)
+        answers.append([_parse_true_false_token(token) for token in tokens])
+    return answers
+
+
+def parse_part3_lines(lines: Iterable[str], expected_count: int | None = None) -> List[str]:
+    answers: List[str] = []
+    normalized = _normalize_order(_iter_indexed_lines(lines), expected_count)
+    for value in normalized:
+        answer = re.sub(r"\s+", "", value)
+        answers.append(answer)
+    return answers
+
+
+def parse_answer_document(
+    text: str,
+    statements: int = 4,
+) -> Dict[str, List]:
+    sections: Dict[int, List[str]] = {1: [], 2: [], 3: []}
+    current = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        section = SECTION_RE.match(line)
+        if section:
+            current = int(section.group(1))
+            continue
+        if current in sections:
+            sections[current].append(line)
+
+    part1 = parse_part1_lines(sections[1]) if sections[1] else None
+    part2 = (
+        parse_part2_lines(sections[2], statements=statements) if sections[2] else None
+    )
+    part3 = parse_part3_lines(sections[3]) if sections[3] else None
+
+    return {"part1": part1, "part2": part2, "part3": part3}
+

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -580,7 +580,11 @@ class ContestJoin(LoginRequiredMixin, ContestMixin, BaseDetailView):
         profile.save()
         contest._updating_stats_only = True
         contest.update_user_count()
-        return HttpResponseRedirect(reverse("problem_list"))
+        if contest.format_name == "thptqg" and not participation.spectate:
+            destination = reverse("contest_exam", kwargs={"contest": contest.key})
+        else:
+            destination = reverse("problem_list")
+        return HttpResponseRedirect(destination)
 
     def ask_for_access_code(self, form=None):
         contest = self.object
@@ -928,11 +932,14 @@ def get_contest_ranking_list(
     show_current_virtual=False,
     ranker=ranker,
 ):
-    problems = list(
-        contest.contest_problems.select_related("problem")
-        .defer("problem__description")
-        .order_by("order")
-    )
+    if contest.format_name == "thptqg":
+        problems = contest.format.get_virtual_parts()
+    else:
+        problems = list(
+            contest.contest_problems.select_related("problem")
+            .defer("problem__description")
+            .order_by("order")
+        )
 
     users = ranker(
         ranking_list(contest, problems),

--- a/judge/views/exam.py
+++ b/judge/views/exam.py
@@ -1,0 +1,198 @@
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
+from django.utils.translation import gettext as _
+from django.views.generic import FormView
+
+from judge.forms import ExamSheetForm
+from judge.models import Contest, ContestParticipation, ExamQuestion, ExamResponse
+from judge.utils.views import generic_message
+
+
+class ContestExamView(LoginRequiredMixin, FormView):
+    template_name = "exam/take.html"
+    form_class = ExamSheetForm
+
+    def dispatch(self, request, *args, **kwargs):
+        self.contest = get_object_or_404(Contest, key=kwargs["contest"])
+        if self.contest.format_name != "thptqg":
+            raise PermissionDenied
+
+        try:
+            self.participation = self.get_participation()
+        except ContestParticipation.DoesNotExist:
+            return generic_message(
+                request,
+                _("Join required"),
+                _("You need to join this contest to access the exam."),
+            )
+
+        self.paper = getattr(self.contest, "exam_paper", None)
+        if not self.paper:
+            return generic_message(
+                request,
+                _("Exam not configured"),
+                _("This contest does not have an exam paper yet."),
+            )
+
+        self.questions = list(
+            self.paper.questions.select_related("paper")
+            .prefetch_related("choices")
+            .order_by("part", "number")
+        )
+        if not self.questions:
+            return generic_message(
+                request,
+                _("No exam questions"),
+                _("This contest does not have any configured exam questions."),
+            )
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_participation(self):
+        profile = getattr(self.request, "profile", None)
+        if profile is None:
+            raise PermissionDenied
+
+        participation = getattr(self.request, "participation", None)
+        if (
+            participation
+            and participation.contest_id == self.contest.id
+            and participation.user_id == profile.id
+        ):
+            return participation
+
+        return ContestParticipation.objects.get(
+            contest=self.contest,
+            user=profile,
+            virtual__in=[
+                ContestParticipation.LIVE,
+                ContestParticipation.SPECTATE,
+            ],
+        )
+
+    def get_responses(self):
+        if not hasattr(self, "_responses"):
+            self._responses = {
+                response.question_id: response
+                for response in ExamResponse.objects.filter(
+                    participation=self.participation,
+                    question__paper=self.paper,
+                ).select_related("selected_choice")
+            }
+        return self._responses
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update(
+            {
+                "paper": self.paper,
+                "questions": self.questions,
+                "responses": self.get_responses(),
+            }
+        )
+        return kwargs
+
+    def form_valid(self, form):
+        responses = self.get_responses()
+        updated = False
+
+        # Part I – multiple choice
+        for question, field_name in form.multiple_choice_field_map:
+            choice_key = form.cleaned_data.get(field_name)
+            existing = responses.get(question.id)
+            if not choice_key and existing is None:
+                continue
+            response = existing or ExamResponse(
+                question=question, participation=self.participation
+            )
+            selected_choice = None
+            if choice_key:
+                selected_choice = form.choice_lookup.get(question.id, {}).get(choice_key)
+            response.selected_choice = selected_choice
+            response.true_false_answers = {}
+            response.short_answer_text = ""
+            response.save(recompute=False)
+            responses[question.id] = response
+            updated = True
+
+        # Part II – True/False statements
+        for question, entries in form.true_false_field_map.items():
+            answers = {}
+            has_value = False
+            for choice, field_name in entries:
+                value = form.cleaned_data.get(field_name)
+                if value in {"true", "false"}:
+                    answers[str(choice.id)] = value == "true"
+                    has_value = True
+            existing = responses.get(question.id)
+            if existing is None and not has_value:
+                continue
+            response = existing or ExamResponse(
+                question=question, participation=self.participation
+            )
+            response.true_false_answers = answers
+            response.selected_choice = None
+            response.short_answer_text = ""
+            response.save(recompute=False)
+            responses[question.id] = response
+            updated = True
+
+        # Part III – short answers
+        for question, field_name in form.short_answer_field_map:
+            value = form.cleaned_data.get(field_name, "")
+            value = (value or "").strip()
+            existing = responses.get(question.id)
+            if not value and existing is None:
+                continue
+            response = existing or ExamResponse(
+                question=question, participation=self.participation
+            )
+            response.short_answer_text = value
+            response.selected_choice = None
+            response.true_false_answers = {}
+            response.save(recompute=False)
+            responses[question.id] = response
+            updated = True
+
+        if updated:
+            self.participation.recompute_results()
+
+        messages.success(self.request, _("Your answers have been saved."))
+
+        if "finish" in self.request.POST:
+            return redirect("contest_ranking", contest=self.contest.key)
+
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse("contest_exam", kwargs={"contest": self.contest.key})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        form = context.get("form")
+        context.update(
+            {
+                "contest": self.contest,
+                "participation": self.participation,
+                "paper": self.paper,
+                "part1_questions": form.part1_questions if form else [],
+                "part2_questions": form.part2_questions if form else [],
+                "part3_questions": form.part3_questions if form else [],
+                "has_part3": bool(self.paper.part3_questions),
+                "responses": self.get_responses(),
+                "part_counts": {
+                    "part1": self.paper.part1_questions,
+                    "part2": self.paper.part2_questions,
+                    "part3": self.paper.part3_questions,
+                },
+                "part_points": {
+                    "part1": self.paper.part1_point_value,
+                    "part2": self.paper.part2_point_value,
+                    "part3": self.paper.part3_point_value,
+                },
+            }
+        )
+        return context

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -232,9 +232,6 @@ msgid "Language"
 msgstr "Ngôn ngữ"
 
 #: judge/admin/problem.py:220
-msgid "History"
-msgstr "Lịch sử"
-
 #: judge/admin/problem.py:272 templates/problem/list-base.html:108
 msgid "Authors"
 msgstr "Các tác giả"
@@ -5943,3 +5940,192 @@ msgstr "Chọn tất cả"
 
 #~ msgid "Hard"
 #~ msgstr "Khó"
+
+msgid "THPTQG Exam"
+msgstr "Kỳ thi THPTQG"
+
+msgid "Score (0-10)"
+msgstr "Điểm (0-10)"
+
+msgid "Go to exam interface"
+msgstr "Vào làm bài thi"
+
+msgid "Exam"
+msgstr "Bài thi"
+
+msgid "Question %(current)s of %(total)s"
+msgstr "Câu hỏi %(current)s/%(total)s"
+
+msgid "Time remaining:"
+msgstr "Thời gian còn lại:"
+
+msgid "Question prompt"
+msgstr "Đề bài"
+
+msgid "Previous"
+msgstr "Trước"
+
+msgid "Save and next"
+msgstr "Lưu và tiếp"
+
+msgid "Finish exam"
+msgstr "Nộp bài"
+
+msgid "Join required"
+msgstr "Cần tham gia"
+
+msgid "You need to join this contest to access the exam."
+msgstr "Bạn cần tham gia kỳ thi này để vào làm bài."
+
+msgid "No exam questions"
+msgstr "Chưa có câu hỏi"
+
+msgid "This contest does not have any configured exam questions."
+msgstr "Kỳ thi này chưa được cấu hình câu hỏi trắc nghiệm."
+
+msgid "Your answer has been saved."
+msgstr "Đã lưu câu trả lời của bạn."
+
+msgid "Multiple choice"
+msgstr "Trắc nghiệm"
+
+msgid "True/False"
+msgstr "Đúng/Sai"
+
+msgid "Short answer"
+msgstr "Điền đáp án"
+
+msgid "Answer"
+msgstr "Đáp án"
+
+msgid "True"
+msgstr "Đúng"
+
+msgid "False"
+msgstr "Sai"
+
+msgid "Mathematics"
+msgstr "Toán học"
+
+msgid "Physics"
+msgstr "Vật lý"
+
+msgid "Chemistry"
+msgstr "Hóa học"
+
+msgid "Biology"
+msgstr "Sinh học"
+
+msgid "History"
+msgstr "Lịch sử"
+
+msgid "Geography"
+msgstr "Địa lý"
+
+msgid "Civic education"
+msgstr "Giáo dục công dân"
+
+msgid "Other foreign language"
+msgstr "Ngoại ngữ khác"
+
+msgid "part I questions"
+msgstr "số câu phần I"
+
+msgid "part II questions"
+msgstr "số câu phần II"
+
+msgid "part III questions"
+msgstr "số câu phần III"
+
+msgid "exam PDF"
+msgstr "file đề thi PDF"
+
+msgid "exam paper"
+msgstr "đề thi"
+
+msgid "Manual part I answers"
+msgstr "Nhập đáp án phần I"
+
+msgid "One question per line, e.g. \"1. A\"."
+msgstr "Mỗi dòng một câu, ví dụ \"1. A\"."
+
+msgid "Manual part II answers"
+msgstr "Nhập đáp án phần II"
+
+msgid "Use Đ for true and S for false, e.g. \"1. Đ S S Đ\"."
+msgstr "Dùng Đ cho đúng và S cho sai, ví dụ \"1. Đ S S Đ\"."
+
+msgid "Manual part III answers"
+msgstr "Nhập đáp án phần III"
+
+msgid "One short answer per line, e.g. \"1. 12345\"."
+msgstr "Mỗi dòng một đáp án ngắn, ví dụ \"1. 12345\"."
+
+msgid "Upload answer file"
+msgstr "Tải tệp đáp án"
+
+msgid "Accepted .docx or .pdf with sections [PART1], [PART2], [PART3]. Example: [PART1]\n1. A\n…"
+msgstr "Chấp nhận tệp .docx hoặc .pdf với các phần [PART1], [PART2], [PART3]. Ví dụ: [PART1]\n1. A\n…"
+
+msgid "Choose either manual answers or an uploaded file, not both."
+msgstr "Chỉ chọn một trong hai cách: nhập thủ công hoặc tải tệp đáp án."
+
+msgid "Exam not configured"
+msgstr "Chưa thiết lập đề thi"
+
+msgid "This contest does not have an exam paper yet."
+msgstr "Kỳ thi này chưa có đề thi."
+
+msgid "Your answers have been saved."
+msgstr "Đã lưu câu trả lời của bạn."
+
+msgid "Part I"
+msgstr "Phần I"
+
+msgid "Part II"
+msgstr "Phần II"
+
+msgid "Part III"
+msgstr "Phần III"
+
+msgid "%(count)s questions"
+msgstr "%(count)s câu hỏi"
+
+msgid "Exam document"
+msgstr "Đề thi"
+
+msgid "Exam PDF is not available yet."
+msgstr "Chưa có file PDF của đề thi."
+
+msgid "Part I – Multiple choice"
+msgstr "Phần I – Trắc nghiệm"
+
+msgid "Part II – True/False"
+msgstr "Phần II – Đúng/Sai"
+
+msgid "Part III – Short answers"
+msgstr "Phần III – Điền đáp án"
+
+msgid "%(count)s questions · %(points)s pts/question"
+msgstr "%(count)s câu · %(points)s điểm/câu"
+
+msgid "%(count)s questions · up to %(points)s pts/question"
+msgstr "%(count)s câu · tối đa %(points)s điểm/câu"
+
+msgid "Part I: %(count)s questions"
+msgstr "Phần I: %(count)s câu"
+
+msgid "Part II: %(count)s questions × 4 statements"
+msgstr "Phần II: %(count)s câu × 4 ý"
+
+msgid "Part III: %(count)s questions"
+msgstr "Phần III: %(count)s câu"
+
+msgid "Save answers"
+msgstr "Lưu đáp án"
+
+msgid "Submit and view ranking"
+msgstr "Nộp bài và xem bảng xếp hạng"
+
+msgid "Clear selection on screen"
+msgstr "Xóa lựa chọn trên màn hình"

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,6 @@ bleach
 pymdown-extensions
 mdx-breakless-lists
 beautifulsoup4
+PyMySQL>=1.0
+python-docx
+pdfminer.six

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -77,7 +77,13 @@
             <input type="submit" class="btn-midnightblue" value="{{ _('Login to participate') }}">
         </form>
     {% endif %}
-    
+
+    {% if contest.format_name == 'thptqg' and contest.exam_paper_id and contest.is_in_contest(request.user) %}
+        <a class="contest-join-pseudotab btn-midnightblue" href="{{ url('contest_exam', contest.key) }}">
+            {{ _('Go to exam interface') }}
+        </a>
+    {% endif %}
+
     <div class="content-description">
         {% cache 3600 'contest_html' contest.id MATH_ENGINE %}
             {{ contest.description|markdown|reference|str|safe }}

--- a/templates/contest/ranking-table.html
+++ b/templates/contest/ranking-table.html
@@ -1,6 +1,9 @@
 {% extends "user/base-users-table.html" %}
 
 {% set friends = request.profile.get_friends() if request.user.is_authenticated else {} %}
+{% if contest.format_name == 'thptqg' %}
+    {% set points_header = _('Score (0-10)') %}
+{% endif %}
 
 {% block after_rank_head %}
     {% if has_rating %}
@@ -56,11 +59,18 @@
     <th class="full-name" style="display:none;">{{ _('Fullname') }}</th>
     <th style="display:none;">{{ _('School') }}</th>
     {% for problem in problems %}
-        <th class="points header problem-score-col" title="{{ problem.problem.name }}"><a href="{{ url('problem_detail', problem.problem.code) }}">
-            {{- contest.get_label_for_problem(loop.index0) }}
-            <div class="point-denominator">{{ problem.points }}</div>
-            <div class="problem-code" style="display: none;">{{ problem.problem.code }}</div>
-        </a></th>
+        {% if contest.format_name == 'thptqg' %}
+            <th class="points header problem-score-col exam-part-header">
+                <div class="exam-part-name">{{ problem.label }}</div>
+                <div class="point-denominator">{{ problem.points|floatformat(2) }}</div>
+            </th>
+        {% else %}
+            <th class="points header problem-score-col" title="{{ problem.problem.name }}"><a href="{{ url('problem_detail', problem.problem.code) }}">
+                {{- contest.get_label_for_problem(loop.index0) }}
+                <div class="point-denominator">{{ problem.points }}</div>
+                <div class="problem-code" style="display: none;">{{ problem.problem.code }}</div>
+            </a></th>
+        {% endif %}
     {% endfor %}
 {% endblock %}
 

--- a/templates/exam/take.html
+++ b/templates/exam/take.html
@@ -1,0 +1,450 @@
+{% extends "base.html" %}
+
+{% block title %}{{ contest.name }} – {{ _('Exam') }}{% endblock %}
+
+{% block media %}
+    <style>
+        .exam-shell {
+            max-width: 1280px;
+            margin: 2rem auto;
+            padding: 0 1rem 2rem;
+        }
+
+        .exam-header {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 1.5rem;
+        }
+
+        .exam-header h1 {
+            margin: 0;
+            font-size: 1.8rem;
+            color: #1d3557;
+        }
+
+        .exam-summary {
+            color: #475569;
+            font-size: 0.95rem;
+            margin-top: 0.35rem;
+            line-height: 1.4;
+        }
+
+        .exam-timer {
+            font-size: 1rem;
+            color: #ef4444;
+            font-weight: 600;
+        }
+
+        #contest-time-remaining {
+            font-weight: 700;
+        }
+
+        .exam-body {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            align-items: flex-start;
+        }
+
+        .exam-document,
+        .exam-sheet {
+            background: #ffffff;
+            border-radius: 14px;
+            box-shadow: 0 18px 45px -20px rgba(15, 23, 42, 0.25);
+        }
+
+        .exam-document {
+            flex: 1 1 420px;
+            min-width: 320px;
+            overflow: hidden;
+        }
+
+        .exam-document iframe,
+        .exam-document object {
+            width: 100%;
+            height: 82vh;
+            border: none;
+        }
+
+        .exam-document .no-document {
+            padding: 2.5rem;
+            text-align: center;
+            color: #64748b;
+            font-size: 1rem;
+        }
+
+        .exam-sheet {
+            flex: 1 1 520px;
+            min-width: 320px;
+            padding: 1.75rem 2rem;
+        }
+
+        .sheet-section {
+            margin-bottom: 1.75rem;
+        }
+
+        .sheet-section h2 {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin: 0 0 0.85rem;
+            font-size: 1.1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: #264653;
+        }
+
+        .section-meta {
+            font-size: 0.85rem;
+            color: #64748b;
+            font-weight: 500;
+        }
+
+        .bubble-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .bubble-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.8rem 1rem;
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            background: #f8fafc;
+        }
+
+        .bubble-number {
+            font-weight: 700;
+            color: #1d3557;
+            min-width: 2rem;
+            text-align: center;
+        }
+
+        .bubble-options {
+            display: flex;
+            gap: 0.55rem;
+        }
+
+        .bubble-option {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .bubble-option input {
+            position: absolute;
+            opacity: 0;
+        }
+
+        .bubble-option span {
+            width: 34px;
+            height: 34px;
+            border-radius: 50%;
+            border: 2px solid #cbd5f5;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            color: #475569;
+            transition: all 0.2s ease;
+            background: #ffffff;
+        }
+
+        .bubble-option input:checked + span {
+            background: #2563eb;
+            border-color: #1d4ed8;
+            color: #ffffff;
+            box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+        }
+
+        .bubble-option input:focus + span {
+            box-shadow: 0 0 0 2px rgba(14, 116, 144, 0.3);
+        }
+
+        .bubble-option:hover span {
+            border-color: #2563eb;
+        }
+
+        .true-false-grid {
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .true-false-row {
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            padding: 0.75rem 1rem 0.9rem;
+            background: #ffffff;
+        }
+
+        .true-false-statements {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 0.6rem;
+        }
+
+        .statement-block {
+            border: 1px dashed #cbd5f5;
+            border-radius: 8px;
+            padding: 0.6rem;
+            background: #f8fafc;
+        }
+
+        .statement-label {
+            font-weight: 700;
+            color: #1d3557;
+            margin-bottom: 0.45rem;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .statement-options {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .statement-option {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+        }
+
+        .statement-option input {
+            position: absolute;
+            opacity: 0;
+        }
+
+        .statement-option span {
+            padding: 0.35rem 0.8rem;
+            border-radius: 999px;
+            border: 1px solid #cbd5f5;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #475569;
+            transition: all 0.2s ease;
+            background: #ffffff;
+        }
+
+        .statement-option input:checked + span {
+            background: #0ea5e9;
+            border-color: #0284c7;
+            color: #ffffff;
+            box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.2);
+        }
+
+        .statement-option:hover span {
+            border-color: #0284c7;
+        }
+
+        .short-answer-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .short-answer-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.75rem 1rem;
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            background: #f8fafc;
+        }
+
+        .short-answer-field {
+            width: 100%;
+            padding: 0.55rem 0.85rem;
+            font-size: 1.05rem;
+            font-weight: 600;
+            letter-spacing: 0.35rem;
+            text-transform: uppercase;
+            text-align: center;
+            border: 2px solid #cbd5f5;
+            border-radius: 8px;
+            background: #ffffff;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .short-answer-field:focus {
+            border-color: #2563eb;
+            box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+            outline: none;
+        }
+
+        .exam-actions {
+            margin-top: 1.5rem;
+            display: flex;
+            gap: 0.85rem;
+            flex-wrap: wrap;
+        }
+
+        .exam-actions button {
+            padding: 0.6rem 1.6rem;
+            border: none;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.1s ease, box-shadow 0.1s ease;
+        }
+
+        .exam-actions button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 18px -12px rgba(15, 23, 42, 0.35);
+        }
+
+        .btn-save {
+            background: linear-gradient(135deg, #0ea5e9, #2563eb);
+            color: #ffffff;
+        }
+
+        .btn-finish {
+            background: linear-gradient(135deg, #f97316, #ef4444);
+            color: #ffffff;
+        }
+
+        .btn-reset {
+            background: #e2e8f0;
+            color: #334155;
+        }
+
+        @media (max-width: 960px) {
+            .exam-document iframe,
+            .exam-document object {
+                height: 70vh;
+            }
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+<div class="exam-shell">
+    <div class="exam-header">
+        <div>
+            <h1>{{ contest.name }}</h1>
+            <div class="exam-summary">
+                {{ paper.get_subject_display }} ·
+                {{ _('Part I: %(count)s questions')|format(count=part_counts.part1) }},
+                {{ _('Part II: %(count)s questions × 4 statements')|format(count=part_counts.part2) }}{% if has_part3 and part_counts.part3 %},
+                {{ _('Part III: %(count)s questions')|format(count=part_counts.part3) }}{% endif %}
+            </div>
+        </div>
+        {% if participation.end_time %}
+            <div class="exam-timer">
+                {{ _('Time remaining:') }}
+                <span id="contest-time-remaining" data-secs="{{ participation.end_time|date('c') }}">
+                    {{ participation.time_remaining|timedelta('localized') if participation.time_remaining }}
+                </span>
+            </div>
+        {% endif %}
+    </div>
+
+    {% include "messages.html" %}
+
+    <div class="exam-body">
+        <div class="exam-document">
+            {% if paper.pdf %}
+                <iframe src="{{ paper.pdf.url }}#toolbar=0" title="{{ _('Exam document') }}"></iframe>
+            {% else %}
+                <div class="no-document">{{ _('Exam PDF is not available yet.') }}</div>
+            {% endif %}
+        </div>
+
+        <div class="exam-sheet">
+            <form method="post">
+                {% csrf_token %}
+                {{ form.non_field_errors }}
+
+                <div class="sheet-section">
+                    <h2>
+                        {{ _('Part I – Multiple choice') }}
+                        <span class="section-meta">
+                            {{ _('%(count)s questions · %(points)s pts/question')|format(count=part_counts.part1, points=part_points.part1|floatformat(2)) }}
+                        </span>
+                    </h2>
+                    <div class="bubble-grid">
+                        {% for question, field in form.iter_part1() %}
+                            <div class="bubble-row">
+                                <div class="bubble-number">{{ question.number }}</div>
+                                <div class="bubble-options">
+                                    {% for radio in field %}
+                                        <label class="bubble-option">
+                                            {{ radio.tag }}
+                                            <span>{{ radio.choice_label }}</span>
+                                        </label>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="sheet-section">
+                    <h2>
+                        {{ _('Part II – True/False') }}
+                        <span class="section-meta">
+                            {{ _('%(count)s questions · up to %(points)s pts/question')|format(count=part_counts.part2, points=part_points.part2|floatformat(2)) }}
+                        </span>
+                    </h2>
+                    <div class="true-false-grid">
+                        {% for question, statements in form.iter_part2() %}
+                            <div class="true-false-row">
+                                <div class="bubble-number">{{ question.number }}</div>
+                                <div class="true-false-statements">
+                                    {% for choice, field in statements %}
+                                        <div class="statement-block">
+                                            <div class="statement-label">{{ choice.key|upper }}</div>
+                                            <div class="statement-options">
+                                                {% for radio in field %}
+                                                    <label class="statement-option">
+                                                        {{ radio.tag }}
+                                                        <span>{{ radio.choice_label }}</span>
+                                                    </label>
+                                                {% endfor %}
+                                            </div>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                {% if has_part3 and part3_questions %}
+                    <div class="sheet-section">
+                        <h2>
+                            {{ _('Part III – Short answers') }}
+                            <span class="section-meta">
+                                {{ _('%(count)s questions · %(points)s pts/question')|format(count=part_counts.part3, points=part_points.part3|floatformat(2)) }}
+                            </span>
+                        </h2>
+                        <div class="short-answer-grid">
+                            {% for question, field in form.iter_part3() %}
+                                <div class="short-answer-row">
+                                    <div class="bubble-number">{{ question.number }}</div>
+                                    <div class="short-answer-input">
+                                        {{ field }}
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+
+                <div class="exam-actions">
+                    <button type="submit" class="btn-save" name="save">{{ _('Save answers') }}</button>
+                    <button type="submit" class="btn-finish" name="finish">{{ _('Submit and view ranking') }}</button>
+                    <button type="reset" class="btn-reset">{{ _('Clear selection on screen') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/user/base-users-table.html
+++ b/templates/user/base-users-table.html
@@ -7,7 +7,7 @@
 
     <th class="header points">
         {% if sort_links %}<a href="{{ sort_links.performance_points }}">{% endif %}
-        {{ _('Points') }}
+        {{ points_header|default(_('Points')) }}
         {%- if sort_links %}{{ sort_order.performance_points }}</a>{% endif %}
     </th>
     {% block after_point_head %}{% endblock %}


### PR DESCRIPTION
## Summary
- add the ExamPaper model with numbering updates and a dedicated migration so contest problems link to three-part exam content
- wire an admin form plus DOCX/PDF import helpers to populate answer keys and synchronize generated questions
- deliver the THPTQG exam-taking flow with the PDF viewer, answer sheet UI, and scoreboard formatting updates for per-part scoring

## Testing
- python manage.py makemigrations --check
- python manage.py check

------