### PR TITLE
Style THPTQG exam actions with OJ buttons

### DIFF
--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -21,13 +21,41 @@
     {% include "actionbar/media-css.html" %}
     <style>
         .contest-exam-launch {
-            margin: 1rem 0;
+            margin: 1.5rem 0;
+            text-align: center;
         }
 
         .contest-exam-launch-button {
-            display: inline-block;
-            padding: 0.65rem 1.5rem;
-            text-align: center;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.45rem;
+            padding: 0.85rem 2.4rem;
+            font-size: 1.05rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            border-radius: 0.5rem;
+            box-shadow: rgba(15, 23, 42, 0.16) 0 12px 24px -12px;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            animation: contest-exam-button-pulse 3s ease-in-out infinite;
+        }
+
+        .contest-exam-launch-button:hover,
+        .contest-exam-launch-button:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: rgba(15, 23, 42, 0.28) 0 18px 32px -12px;
+            animation-play-state: paused;
+        }
+
+        @keyframes contest-exam-button-pulse {
+            0%,
+            100% {
+                box-shadow: rgba(15, 23, 42, 0.16) 0 12px 24px -12px;
+            }
+
+            50% {
+                box-shadow: rgba(29, 78, 216, 0.4) 0 16px 32px -14px;
+            }
         }
     </style>
 {% endblock %}
@@ -91,7 +119,7 @@
 
     {% if contest.format_name == 'thptqg' and contest.exam_papers.exists() and contest.is_in_contest(request.user) %}
         <div class="contest-exam-launch">
-            <a class="btn-midnightblue contest-exam-launch-button" href="{{ url('contest_exam', contest.key) }}">
+            <a class="button btn-midnightblue contest-exam-launch-button" href="{{ url('contest_exam', contest.key) }}">
                 {{ _('Go to exam interface') }}
             </a>
         </div>

--- a/templates/exam/take.html
+++ b/templates/exam/take.html
@@ -13,6 +13,7 @@
             max-width: 1280px;
             margin: 2rem auto;
             padding: 0 1rem 2rem;
+            font-family: inherit;
         }
 
         .exam-shell[data-exam-locked="true"] form,
@@ -348,33 +349,41 @@
             flex-wrap: wrap;
         }
 
-        .exam-actions button {
-            padding: 0.6rem 1.6rem;
-            border: none;
-            border-radius: 999px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: transform 0.1s ease, box-shadow 0.1s ease;
+        .exam-actions .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.35rem;
+            min-height: 0;
+            padding: 0.75rem 1.8rem;
+            border-radius: 0.25rem;
+            box-shadow: rgba(15, 23, 42, 0.08) 0 6px 14px -6px;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
         }
 
-        .exam-actions button:hover {
+        .exam-actions .button:hover {
             transform: translateY(-1px);
-            box-shadow: 0 10px 18px -12px rgba(15, 23, 42, 0.35);
+            box-shadow: rgba(15, 23, 42, 0.18) 0 8px 18px -6px;
         }
 
-        .btn-save {
-            background: linear-gradient(135deg, #0ea5e9, #2563eb);
-            color: #ffffff;
+        .exam-actions .exam-action-submit {
+            box-shadow: rgba(34, 197, 94, 0.45) 0 12px 20px -10px;
         }
 
-        .btn-finish {
-            background: linear-gradient(135deg, #f97316, #ef4444);
-            color: #ffffff;
+        .exam-actions .exam-action-submit:hover {
+            box-shadow: rgba(34, 197, 94, 0.55) 0 16px 26px -10px;
         }
 
-        .btn-reset {
+        .exam-actions .exam-action-reset {
             background: #e2e8f0;
-            color: #334155;
+            border: 1px solid #cbd5e1;
+            color: #1f2937 !important;
+            box-shadow: none;
+        }
+
+        .exam-actions .exam-action-reset:hover {
+            background: #cbd5e1;
+            color: #0f172a !important;
         }
 
         @media (max-width: 960px) {
@@ -406,15 +415,13 @@
             display: flex;
         }
 
-        .fullscreen-overlay button {
-            padding: 0.8rem 2.5rem;
-            border-radius: 999px;
-            background: linear-gradient(135deg, #1d4ed8, #2563eb);
-            color: white;
-            border: none;
+        .fullscreen-overlay .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.9rem 2.5rem;
             font-size: 1rem;
             font-weight: 700;
-            cursor: pointer;
         }
 
         .fullscreen-overlay p {
@@ -851,9 +858,9 @@
                 {% endif %}
 
                 <div class="exam-actions">
-                    <button type="submit" class="btn-save" name="save" {% if exam_read_only %}disabled{% endif %}>{{ _('Save answers') }}</button>
-                    <button type="submit" class="btn-finish" name="finish" {% if exam_read_only %}disabled{% endif %}>{{ _('Submit and view ranking') }}</button>
-                    <button type="reset" class="btn-reset" {% if exam_read_only %}disabled{% endif %}>{{ _('Clear selection on screen') }}</button>
+                    <button type="submit" class="button btn-midnightblue exam-action-save" name="save" {% if exam_read_only %}disabled{% endif %}>{{ _('Save answers') }}</button>
+                    <button type="submit" class="button btn-green exam-action-submit" name="finish" {% if exam_read_only %}disabled{% endif %}>{{ _('Submit and view ranking') }}</button>
+                    <button type="reset" class="button exam-action-reset" {% if exam_read_only %}disabled{% endif %}>{{ _('Clear selection on screen') }}</button>
                 </div>
             </form>
         </div>
@@ -863,6 +870,6 @@
 <div id="fullscreen-overlay" class="fullscreen-overlay">
     <h2>{{ _('Full-screen mode required') }}</h2>
     <p>{{ _('To continue the exam, please switch to full-screen mode and keep the exam window active. Leaving full-screen will be recorded as a violation.') }}</p>
-    <button type="button">{{ _('Enter full-screen') }}</button>
+    <button type="button" class="button btn-midnightblue">{{ _('Enter full-screen') }}</button>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- align the THPTQG exam interface with the site font and button styling, including the full-screen prompt
- refresh the exam launch link on contest pages so it uses the standard button component and stands out more prominently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d56ba75c1883318bc30a08f7c2269e