### PR TITLE
Add ICPC public scoreboard view

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Hệ thống bảng xếp hạng thời gian thực, event trực tiếp bằng WebSocket và newsletter tương tác với thí sinh.
 - Contest format **Codeforces** tái hiện đầy đủ luật tính điểm chính thức (dynamic scoring, penalty, freeze) cho kỳ thi lập trình đối kháng.
 - Nguồn dữ liệu tương thích **ICPC Resolver**, tự động đồng bộ contest dạng ICPC qua bộ API `/icpc/…` và feed sự kiện NDJSON.
+- Bảng xếp hạng **ICPC** có thể bật chế độ public riêng (ngoài toggle scoreboard chung) để chia sẻ kết quả cho khán giả theo link `/contest/<contest-key>/icpc-scoreboard/`.
 
 ### Thể thức trắc nghiệm THPTQG 2025
 - Contest format **THPTQG Exam** chấm điểm theo thang 0–10 dựa trên tổng điểm tối đa của từng phần và hiển thị chi tiết số điểm/ý đúng trên bảng xếp hạng.

--- a/dmoj/urls.py
+++ b/dmoj/urls.py
@@ -525,6 +525,11 @@ urlpatterns = [
                     name="contest_ranking",
                 ),
                 url(
+                    r"^/icpc-scoreboard/$",
+                    contests.ContestICPCScoreboard.as_view(),
+                    name="contest_icpc_scoreboard",
+                ),
+                url(
                     r"^/ranking/ajax$",
                     contests.contest_ranking_ajax,
                     name="contest_ranking_ajax",

--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -161,6 +161,7 @@ class ContestAdmin(CompareVersionAdmin):
                     "use_clarifications",
                     "hide_problem_tags",
                     "scoreboard_visibility",
+                    "icpc_public_scoreboard",
                     "run_pretests_only",
                     "points_precision",
                 )

--- a/judge/migrations/0144_contest_icpc_public_scoreboard.py
+++ b/judge/migrations/0144_contest_icpc_public_scoreboard.py
@@ -1,0 +1,21 @@
+# Generated manually for adding ICPC public scoreboard flag
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0143_auto_20250923_0122'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contest',
+            name='icpc_public_scoreboard',
+            field=models.BooleanField(
+                default=False,
+                help_text='Allow the ICPC-specific scoreboard page to be accessed publicly once the scoreboard itself is visible.',
+                verbose_name='public ICPC scoreboard',
+            ),
+        ),
+    ]

--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -150,6 +150,14 @@ class Contest(models.Model):
         help_text=_("Whether this contest can be rated."),
         default=False,
     )
+    icpc_public_scoreboard = models.BooleanField(
+        verbose_name=_("public ICPC scoreboard"),
+        default=False,
+        help_text=_(
+            "Allow the ICPC-specific scoreboard page to be accessed publicly "
+            "once the scoreboard itself is visible."
+        ),
+    )
     scoreboard_visibility = models.CharField(
         verbose_name=_("scoreboard visibility"),
         default=SCOREBOARD_VISIBLE,

--- a/templates/contest/icpc-scoreboard.html
+++ b/templates/contest/icpc-scoreboard.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+
+{% block title %}{{ contest.name }} – {{ _('ICPC Scoreboard') }}{% endblock %}
+
+{% block media %}
+    {{ super() }}
+    <style>
+        .icpc-scoreboard-table table {
+            margin-bottom: 0;
+        }
+
+        .icpc-scoreboard-table th,
+        .icpc-scoreboard-table td {
+            vertical-align: middle !important;
+        }
+
+        .icpc-display-name {
+            font-weight: 700;
+            font-size: 1.05em;
+        }
+
+        .icpc-problem-cell {
+            min-width: 70px;
+        }
+    </style>
+{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <div class="page-header">
+            <h1>{{ contest.name }} <small>{{ _('ICPC Scoreboard') }}</small></h1>
+            <p class="text-muted">
+                {% if is_public_view %}
+                    {{ _('This ICPC scoreboard is public, as enabled by an administrator.') }}
+                {% else %}
+                    {{ _('This ICPC scoreboard is only visible to contest staff and authorized viewers.') }}
+                {% endif %}
+            </p>
+        </div>
+
+        {% if scoreboard_hidden %}
+            <div class="alert alert-info">{{ _('Scoreboard is currently hidden for this contest.') }}</div>
+        {% elif not rows %}
+            <div class="alert alert-info">{{ _('No participants have been ranked yet.') }}</div>
+        {% else %}
+            <div class="table-responsive icpc-scoreboard-table">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th style="width: 5%;">#</th>
+                            <th style="width: 25%;">{{ _('Team') }}</th>
+                            <th style="width: 10%;" class="text-center">{{ _('Result') }}</th>
+                            {% for problem in problems %}
+                                <th class="text-center icpc-problem-cell"
+                                    title="{{ problem.problem.name }}">{{ contest.get_label_for_problem(loop.index0) }}</th>
+                            {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in rows %}
+                            <tr>
+                                <td>{{ row.rank }}</td>
+                                <td>
+                                    <div class="icpc-display-name">{{ row.display_name }}</div>
+                                    {% if row.username and row.username != row.display_name %}
+                                        <div class="text-muted small">@{{ row.username }}</div>
+                                    {% endif %}
+                                    {% if row.organization %}
+                                        <div class="text-muted small">
+                                            {{ row.organization.short_name or row.organization.name }}
+                                        </div>
+                                    {% endif %}
+                                </td>
+                                <td class="text-center">{{ row.result|safe }}</td>
+                                {% for cell in row.problem_cells %}
+                                    <td class="text-center icpc-problem-cell">{{ cell|safe }}</td>
+                                {% endfor %}
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a per-contest flag that controls whether the ICPC scoreboard page can be made public
- expose the toggle in contest admin and wire a dedicated ICPC scoreboard route
- render a public-facing ICPC scoreboard page that prefers full names over usernames when available
- document how to access the optional public ICPC scoreboard in the README

## Testing
- Not run (COMPRESS_ROOT/STATIC_ROOT not configured for management commands in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bac85b494832989f8be77addd45d6)